### PR TITLE
Rename interrupt pair.ist role for cf-k8s-networking

### DIFF
--- a/config/networking.yml
+++ b/config/networking.yml
@@ -18,7 +18,7 @@ delegatebot:
                 from:
                   pairist:
                     team: cf-k8s-networking
-                    role: "Interrupt [Mon/Fri]"
+                    role: "Interrupt/Community [Mon/Fri]"
                 users: &usrs
                   Aidan: U8WQW0FV0
                   Alex: UDF8SD3RS


### PR DESCRIPTION
cc @christianang 